### PR TITLE
Bump default god version to 0.13.3.

### DIFF
--- a/lib/moonshine/god.rb
+++ b/lib/moonshine/god.rb
@@ -4,7 +4,7 @@ module Moonshine
     def self.included(manifest)
       manifest.class_eval do
         extend ClassMethods
-        configure :god => {:version => '0.11.0'}
+        configure :god => {:version => '0.13.3'}
       end
     end
 

--- a/spec/moonshine/god_spec.rb
+++ b/spec/moonshine/god_spec.rb
@@ -18,8 +18,8 @@ describe Moonshine::God do
       @manifest.god
     end
 
-    it "should install god 0.11.0" do
-      @manifest.should have_package('god').version('0.11.0')
+    it "should install god 0.13.3" do
+      @manifest.should have_package('god').version('0.13.3')
     end
 
     it "should default to production" do


### PR DESCRIPTION
There is a bug in God which makes it incompatible with ruby 2 until version 0.13.2.  God will keep writing to it's log file until the disk is full.  This seems like a simple change but I did not run the tests as I couldn't figure out how to run them successfully.  You may need to test with older versions which you need to support.  I simply set the god version in the moonshine.yml file (running ruby 2 and rails 3.2.16) but this change may help others in the future.
