### PR TITLE
Ensure god starts correctly after first install

### DIFF
--- a/lib/moonshine/god.rb
+++ b/lib/moonshine/god.rb
@@ -23,24 +23,30 @@ module Moonshine
 
       # tells god where to find the main config file
       file '/etc/default/god',
-           :require => package('god'),
-           :content => "GOD_CONFIG=/etc/god/god.conf"
+           :require => file('/etc/god/god.conf'),
+           :content => "GOD_CONFIG=/etc/god/god.conf",
+           :notify => exec('restart_god')
 
-      file '/etc/god', :ensure => :directory
-      file "/etc/god/#{ENV['RAILS_ENV']}", :ensure => :directory
+      file '/etc/god',
+           :require => package('god'),
+           :ensure => :directory
+
+      file "/etc/god/#{ENV['RAILS_ENV']}",
+           :require => file('/etc/god'),
+           :ensure => :directory
 
       # tells god to load all of the /etc/god/APPNAME.god
       file '/etc/god/god.conf',
-           :require => file('/etc/god'),
+           :require => file("/etc/god/#{configuration[:application]}.god"),
            :backup => false,
-           :notify => exec('restart_god'),
-           :content => template(god_template_dir.join('god.conf.erb'), binding)
+           :content => template(god_template_dir.join('god.conf.erb'), binding),
+           :notify => exec('restart_god')
 
       # tells god to load all of the watches for this application
       file "/etc/god/#{configuration[:application]}.god",
-          :require => file('/etc/god/god.conf'),
-          :content => "God.load '#{configuration[:deploy_to]}/current/config/god/*.god'",
-          :notify => exec('restart_god')
+           :require => file('/etc/god'),
+           :content => "God.load '#{configuration[:deploy_to]}/current/config/god/*.god'",
+           :notify => exec('restart_god')
 
       upstart_path = if Facter.value(:lsbdistrelease).to_f < 10
                        "/etc/event.d/god"
@@ -55,12 +61,12 @@ module Moonshine
                         end
 
       file upstart_path,
+          :require => file('/etc/default/god'),
           :content => template(upstart_template, binding),
           :notify => exec('restart_god')
 
       exec 'restart_god',
           :command => 'stop god || true && start god',
-          :require => file(upstart_path),
           :refreshonly => true
 
       logrotate '/var/log/god.log',


### PR DESCRIPTION
This PR modifies the resource dependencies to ensure that the gem and configuration files are all in place before Puppet will attempt to restart it.

This problem was previously raised with #5, an attempt to fix was made but myself [and others](https://github.com/railsmachine/moonshine_god/issues/5#issuecomment-1211614) still observe it failing.

In practice the exact symptom I was seeing was the god does end up started thanks to the capistrano task `god:restart`, but the daemon is not being monitored (i.e. `sudo status god` returns `god stop/waiting` rather than something like `god start/running, process 31872`).