### PR TITLE
After terminating god, restart it using Upstart

### DIFF
--- a/recipes/god.rb
+++ b/recipes/god.rb
@@ -5,7 +5,7 @@ namespace :god do
   DESC
   task :restart, :roles => :god do
     sudo 'god terminate || true'
-    sudo 'god -c /etc/god/god.conf'
+    sudo 'start god || true'
     sleep 5
   end
 


### PR DESCRIPTION
During the 'god:restart' task `god terminate` is run - when this completes Upstart will detect this and restart god automatically. The current implementation then tries to start a non-daemonized god process (i.e. runs `god -c /etc/god/god.conf`) which then conflicts with the socket already reserved by the daemonized process started by Upstart.

Due to this my log file would have entries like:
```
Socket drbunix:///tmp/god.17165.sock already in use by another instance of god
```

In this PR I've change it to use `start god || true` which instructs Upstart to start the process if it hasn't already, and ignore it if it has already started it. With this fix in place god restart cleanly without any error messages.